### PR TITLE
perf: lay out points using eytzinger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ name = "pav_regression"
 path = "src/lib.rs"
 
 [dependencies]
+eytzinger = { git = "https://github.com/anchpop/rust-eytzinger.git", rev = "ff5d86b8e5280c1f46c86fa135b0e0592cea1135"}
 ordered-float = "3.9.2"
 serde = { version = "1.0.210", features = ["derive"] }
 thiserror = "1.0"

--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -2,9 +2,16 @@ use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 /// Trait for coordinate types used in Point
 pub trait Coordinate:
-    Copy + Clone + PartialOrd + PartialEq +
-    Add<Output = Self> + Sub<Output = Self> + Mul<Self, Output = Self> + Div<Self, Output = Self> +
-    AddAssign + Neg<Output = Self>
+    Copy
+    + Clone
+    + PartialOrd
+    + PartialEq
+    + Add<Output = Self>
+    + Sub<Output = Self>
+    + Mul<Self, Output = Self>
+    + Div<Self, Output = Self>
+    + AddAssign
+    + Neg<Output = Self>
 {
     /// Returns the zero value for this coordinate type.
     ///

--- a/src/isotonic_regression.rs
+++ b/src/isotonic_regression.rs
@@ -1,8 +1,8 @@
+use crate::coordinate::Coordinate;
+use crate::point::{interpolate_two_points, Point};
 use serde::Serialize;
 use std::fmt::{Display, Formatter};
 use thiserror::Error;
-use crate::coordinate::Coordinate;
-use crate::point::{Point, interpolate_two_points};
 
 /// Errors that can occur during isotonic regression
 #[derive(Error, Debug)]
@@ -30,8 +30,7 @@ struct Centroid<T: Coordinate> {
     sum_weight: f64,
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[derive(PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 #[allow(dead_code)]
 /// Specifies the direction of the isotonic regression.
 pub enum Direction {
@@ -47,7 +46,13 @@ impl<T: Coordinate + Display> Display for IsotonicRegression<T> {
         writeln!(f, "\tdirection: {:?},", self.direction)?;
         writeln!(f, "\tpoints:")?;
         for point in &self.points {
-            writeln!(f, "\t\t{}\t{:.2}\t{:.2}", point.x(), point.y(), point.weight())?;
+            writeln!(
+                f,
+                "\t\t{}\t{:.2}\t{:.2}",
+                point.x(),
+                point.y(),
+                point.weight()
+            )?;
         }
         writeln!(f, "\tcentroid_point:")?;
         writeln!(
@@ -77,7 +82,9 @@ impl<T: Coordinate> IsotonicRegression<T> {
     /// let regression = IsotonicRegression::new_ascending(&points).unwrap();
     /// assert_eq!(regression.get_points().len(), 3);
     /// ```
-    pub fn new_ascending(points: &[Point<T>]) -> Result<IsotonicRegression<T>, IsotonicRegressionError> {
+    pub fn new_ascending(
+        points: &[Point<T>],
+    ) -> Result<IsotonicRegression<T>, IsotonicRegressionError> {
         IsotonicRegression::new(points, Direction::Ascending, false)
     }
 
@@ -97,7 +104,9 @@ impl<T: Coordinate> IsotonicRegression<T> {
     /// let regression = IsotonicRegression::new_descending(&points).unwrap();
     /// assert_eq!(regression.get_points().len(), 3);
     /// ```
-    pub fn new_descending(points: &[Point<T>]) -> Result<IsotonicRegression<T>, IsotonicRegressionError> {
+    pub fn new_descending(
+        points: &[Point<T>],
+    ) -> Result<IsotonicRegression<T>, IsotonicRegressionError> {
         IsotonicRegression::new(points, Direction::Descending, false)
     }
 
@@ -120,14 +129,27 @@ impl<T: Coordinate> IsotonicRegression<T> {
     /// let regression = IsotonicRegression::new(&points, Direction::Ascending, false).unwrap();
     /// assert_eq!(regression.get_points().len(), 3);
     /// ```
-    pub fn new(points: &[Point<T>], direction: Direction, intersect_origin: bool) -> Result<IsotonicRegression<T>, IsotonicRegressionError> {
-        let (sum_x, sum_y, sum_weight) = points.iter().try_fold((T::zero(), T::zero(), 0.0), |(sx, sy, sw), point| {
-            if intersect_origin && (point.x().is_sign_negative() || point.y().is_sign_negative()) {
-                Err(IsotonicRegressionError::NegativePointWithIntersectOrigin)
-            } else {
-                Ok((sx + *point.x() * T::from_float(point.weight()), sy + *point.y() * T::from_float(point.weight()), sw + point.weight()))
-            }
-        })?;
+    pub fn new(
+        points: &[Point<T>],
+        direction: Direction,
+        intersect_origin: bool,
+    ) -> Result<IsotonicRegression<T>, IsotonicRegressionError> {
+        let (sum_x, sum_y, sum_weight) =
+            points
+                .iter()
+                .try_fold((T::zero(), T::zero(), 0.0), |(sx, sy, sw), point| {
+                    if intersect_origin
+                        && (point.x().is_sign_negative() || point.y().is_sign_negative())
+                    {
+                        Err(IsotonicRegressionError::NegativePointWithIntersectOrigin)
+                    } else {
+                        Ok((
+                            sx + *point.x() * T::from_float(point.weight()),
+                            sy + *point.y() * T::from_float(point.weight()),
+                            sw + point.weight(),
+                        ))
+                    }
+                })?;
 
         let mut regression = IsotonicRegression {
             direction: direction.clone(),
@@ -271,10 +293,15 @@ impl<T: Coordinate> IsotonicRegression<T> {
     /// ```
     pub fn add_points(&mut self, points: &[Point<T>]) {
         for point in points {
-            assert!(!self.intersect_origin || 
-                (!point.x().is_sign_negative() && !point.y().is_sign_negative()), "With intersect_origin = true, all points must be >= 0 on both x and y axes" );
-            self.centroid_point.sum_x = self.centroid_point.sum_x + *point.x() * T::from_float(point.weight());
-            self.centroid_point.sum_y = self.centroid_point.sum_y + *point.y() * T::from_float(point.weight());
+            assert!(
+                !self.intersect_origin
+                    || (!point.x().is_sign_negative() && !point.y().is_sign_negative()),
+                "With intersect_origin = true, all points must be >= 0 on both x and y axes"
+            );
+            self.centroid_point.sum_x =
+                self.centroid_point.sum_x + *point.x() * T::from_float(point.weight());
+            self.centroid_point.sum_y =
+                self.centroid_point.sum_y + *point.y() * T::from_float(point.weight());
             self.centroid_point.sum_weight = self.centroid_point.sum_weight + point.weight();
         }
 
@@ -282,7 +309,6 @@ impl<T: Coordinate> IsotonicRegression<T> {
         new_points.extend_from_slice(points);
         self.points = isotonic(&new_points, self.direction.clone());
     }
-
 
     /// Remove points from the regression.
     ///
@@ -301,16 +327,23 @@ impl<T: Coordinate> IsotonicRegression<T> {
     /// ```
     pub fn remove_points(&mut self, points: &[Point<T>]) {
         for point in points {
-            assert!(!self.intersect_origin || 
-                (!point.x().is_sign_negative() && !point.y().is_sign_negative()), "With intersect_origin = true, all points must be >= 0 on both x and y axes" );
-            self.centroid_point.sum_x = self.centroid_point.sum_x - *point.x() * T::from_float(point.weight());
-            self.centroid_point.sum_y = self.centroid_point.sum_y - *point.y() * T::from_float(point.weight());
+            assert!(
+                !self.intersect_origin
+                    || (!point.x().is_sign_negative() && !point.y().is_sign_negative()),
+                "With intersect_origin = true, all points must be >= 0 on both x and y axes"
+            );
+            self.centroid_point.sum_x =
+                self.centroid_point.sum_x - *point.x() * T::from_float(point.weight());
+            self.centroid_point.sum_y =
+                self.centroid_point.sum_y - *point.y() * T::from_float(point.weight());
             self.centroid_point.sum_weight = self.centroid_point.sum_weight - point.weight();
         }
 
         let mut new_points = self.points.clone();
         for point in points {
-            if let Some(pos) = new_points.iter().position(|p| p.x() == point.x() && p.y() == point.y() && p.weight() == point.weight()) {
+            if let Some(pos) = new_points.iter().position(|p| {
+                p.x() == point.x() && p.y() == point.y() && p.weight() == point.weight()
+            }) {
                 new_points.remove(pos);
             }
         }
@@ -357,29 +390,41 @@ impl<T: Coordinate> IsotonicRegression<T> {
 fn isotonic<T: Coordinate>(points: &[Point<T>], direction: Direction) -> Vec<Point<T>> {
     let mut merged_points: Vec<Point<T>> = match direction {
         Direction::Ascending => points.to_vec(),
-        Direction::Descending => points.iter().map(|p| Point::new_with_weight(*p.x(), *p.y(), p.weight())).collect(),
+        Direction::Descending => points
+            .iter()
+            .map(|p| Point::new_with_weight(*p.x(), *p.y(), p.weight()))
+            .collect(),
     };
 
     // Sort the points by x, and if x is equal, sort by y descending to ensure that points with the same x
     // get merged.
     merged_points.sort_by(|a, b| {
-        a.x().partial_cmp(b.x())
+        a.x()
+            .partial_cmp(b.x())
             .unwrap_or(std::cmp::Ordering::Equal)
-            .then(b.y().partial_cmp(a.y()).unwrap_or(std::cmp::Ordering::Equal))
+            .then(
+                b.y()
+                    .partial_cmp(a.y())
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
     });
 
-    let iso_points = merged_points.into_iter().fold(Vec::new(), |mut acc: Vec<Point<T>>, mut point| {
-        while let Some(last) = acc.last() {
-            if (direction == Direction::Ascending && last.y() >= point.y()) ||
-               (direction == Direction::Descending && last.y() <= point.y()) {
-                point.merge_with(&acc.pop().unwrap());
-            } else {
-                break;
-            }
-        }
-        acc.push(point);
-        acc
-    });
+    let iso_points =
+        merged_points
+            .into_iter()
+            .fold(Vec::new(), |mut acc: Vec<Point<T>>, mut point| {
+                while let Some(last) = acc.last() {
+                    if (direction == Direction::Ascending && last.y() >= point.y())
+                        || (direction == Direction::Descending && last.y() <= point.y())
+                    {
+                        point.merge_with(&acc.pop().unwrap());
+                    } else {
+                        break;
+                    }
+                }
+                acc.push(point);
+                acc
+            });
 
     match direction {
         Direction::Ascending => iso_points,
@@ -425,7 +470,9 @@ mod tests {
 
     #[test]
     fn test_add_points() {
-        let mut regression = IsotonicRegression::new_ascending(&[Point::new(0.0, 1.0), Point::new(2.0, 2.0)]).unwrap();
+        let mut regression =
+            IsotonicRegression::new_ascending(&[Point::new(0.0, 1.0), Point::new(2.0, 2.0)])
+                .unwrap();
         regression.add_points(&[Point::new(1.0, 1.5)]);
         assert_eq!(regression.get_points().len(), 3);
         assert_eq!(*regression.get_points()[1].x(), 1.0);
@@ -438,7 +485,8 @@ mod tests {
             Point::new(0.0, 1.0),
             Point::new(1.0, 2.0),
             Point::new(2.0, 3.0),
-        ]).unwrap();
+        ])
+        .unwrap();
         regression.remove_points(&[Point::new(1.0, 2.0)]);
         assert_eq!(regression.get_points().len(), 2);
         assert_eq!(*regression.get_points()[0].x(), 0.0);

--- a/src/isotonic_regression.rs
+++ b/src/isotonic_regression.rs
@@ -1,5 +1,6 @@
 use crate::coordinate::Coordinate;
 use crate::point::{interpolate_two_points, Point};
+use eytzinger::SliceExt;
 use serde::Serialize;
 use std::fmt::{Display, Formatter};
 use thiserror::Error;
@@ -45,7 +46,7 @@ impl<T: Coordinate + Display> Display for IsotonicRegression<T> {
         writeln!(f, "IsotonicRegression {{")?;
         writeln!(f, "\tdirection: {:?},", self.direction)?;
         writeln!(f, "\tpoints:")?;
-        for point in &self.points {
+        for point in &self.get_points_sorted() {
             writeln!(
                 f,
                 "\t\t{}\t{:.2}\t{:.2}",
@@ -151,18 +152,19 @@ impl<T: Coordinate> IsotonicRegression<T> {
                     }
                 })?;
 
-        let mut regression = IsotonicRegression {
-            direction: direction.clone(),
-            points: Vec::new(),
+        let mut isotonic_points = isotonic(points, direction.clone());
+        isotonic_points.eytzingerize(&mut eytzinger::permutation::InplacePermutator);
+
+        Ok(IsotonicRegression {
+            direction,
+            points: isotonic_points,
             centroid_point: Centroid {
                 sum_x,
                 sum_y,
                 sum_weight,
             },
             intersect_origin,
-        };
-        regression.add_points(points);
-        Ok(regression)
+        })
     }
 
     /// Find the _y_ point at position `at_x` or None if the regression is empty.
@@ -191,35 +193,48 @@ impl<T: Coordinate> IsotonicRegression<T> {
         let interpolation = if self.points.len() == 1 {
             *self.points[0].y()
         } else {
-            let pos = self
+            let (lte, gt) = self
                 .points
-                .binary_search_by(|p| p.x().partial_cmp(&at_x).unwrap());
-            match pos {
-                Ok(ix) => *self.points[ix].y(),
-                Err(ix) => {
-                    if ix < 1 {
-                        if self.intersect_origin {
-                            interpolate_two_points(
-                                &Point::new(T::zero(), T::zero()),
-                                self.points.first().unwrap(),
-                                at_x,
-                            )
-                        } else {
-                            interpolate_two_points(
-                                self.points.first().unwrap(),
-                                &self.get_centroid_point().unwrap(),
-                                at_x,
-                            )
-                        }
-                    } else if ix >= self.points.len() {
+                .eytzinger_interpolative_search_by(|p| p.x().partial_cmp(&at_x).unwrap());
+
+            match (lte, gt) {
+                // Found exact match or need to interpolate between two points
+                (Some(lower), Some(upper)) => {
+                    interpolate_two_points(&self.points[lower], &self.points[upper], at_x)
+                }
+                // Requested point meets or exceeds the upper bound
+                (Some(upper), None) => {
+                     // at_x is beyond the last point - interpolate with centroid
+                     interpolate_two_points(
+                        &self.get_centroid_point().unwrap(),
+                        &self.points[upper],
+                        at_x,
+                    )
+                }
+                // Requested point is below the lower bound
+                (None, Some(lower)) => {
+                    // at_x is before the first point
+                    if self.intersect_origin {
                         interpolate_two_points(
-                            &self.get_centroid_point().unwrap(),
-                            self.points.last().unwrap(),
+                            &Point::new(T::zero(), T::zero()),
+                            &self.points[lower],
                             at_x,
                         )
                     } else {
-                        interpolate_two_points(&self.points[ix - 1], &self.points[ix], at_x)
+                        interpolate_two_points(
+                            &self.points[lower],
+                            &self.get_centroid_point().unwrap(),
+                            at_x,
+                        )
                     }
+                }
+                // Should never happen - only possible if the slice is empty, which we already checked
+                (None, None) => {
+                    debug_assert!(
+                        false,
+                        "Got None, None from eytzinger_interpolative_search_by on non-empty slice"
+                    );
+                    return None;
                 }
             }
         };
@@ -227,7 +242,7 @@ impl<T: Coordinate> IsotonicRegression<T> {
         Some(interpolation)
     }
 
-    /// Retrieve the points that make up the isotonic regression.
+    /// Retrieve the points that make up the isotonic regression. The points are NOT sorted by x value - they are in eytzinger order.
     ///
     /// # Examples
     ///
@@ -245,6 +260,13 @@ impl<T: Coordinate> IsotonicRegression<T> {
     /// ```
     pub fn get_points(&self) -> &[Point<T>] {
         &self.points
+    }
+
+    /// Retrieve the points that make up the isotonic regression, sorted by x value.
+    pub fn get_points_sorted(&self) -> Vec<Point<T>> {
+        let mut points = self.points.clone();
+        points.sort_by(|a, b| a.x().partial_cmp(b.x()).unwrap());
+        points
     }
 
     /// Retrieve the mean point of the original point set.
@@ -308,6 +330,8 @@ impl<T: Coordinate> IsotonicRegression<T> {
         let mut new_points = self.points.clone();
         new_points.extend_from_slice(points);
         self.points = isotonic(&new_points, self.direction.clone());
+        self.points
+            .eytzingerize(&mut eytzinger::permutation::InplacePermutator);
     }
 
     /// Remove points from the regression.
@@ -348,6 +372,8 @@ impl<T: Coordinate> IsotonicRegression<T> {
             }
         }
         self.points = isotonic(&new_points, self.direction.clone());
+        self.points
+            .eytzingerize(&mut eytzinger::permutation::InplacePermutator);
     }
 
     /// Returns the number of points in the regression.
@@ -364,7 +390,7 @@ impl<T: Coordinate> IsotonicRegression<T> {
     ///     Point::new(3.0, 3.0),
     /// ];
     /// let regression = IsotonicRegression::new_ascending(&points).unwrap();
-    /// assert_eq!(regression.len(), 8);
+    /// assert_eq!(regression.len(), 4);
     /// ```
     pub fn len(&self) -> usize {
         self.centroid_point.sum_weight.round() as usize
@@ -446,10 +472,10 @@ mod tests {
         ];
 
         let regression = IsotonicRegression::new_ascending(points).unwrap();
-        assert_eq!(regression.get_points().len(), 3);
-        assert_eq!(*regression.get_points()[0].y(), 1.0);
-        assert_eq!(*regression.get_points()[1].y(), 1.75);
-        assert_eq!(*regression.get_points()[2].y(), 3.0);
+        assert_eq!(regression.get_points_sorted().len(), 3);
+        assert_eq!(*regression.get_points_sorted()[0].y(), 1.0);
+        assert_eq!(*regression.get_points_sorted()[1].y(), 1.75);
+        assert_eq!(*regression.get_points_sorted()[2].y(), 3.0);
     }
 
     #[test]
@@ -462,10 +488,10 @@ mod tests {
         ];
 
         let regression = IsotonicRegression::new_descending(points).unwrap();
-        assert_eq!(regression.get_points().len(), 3);
-        assert_eq!(*regression.get_points()[0].y(), 3.0);
-        assert_eq!(*regression.get_points()[1].y(), 2.25);
-        assert_eq!(*regression.get_points()[2].y(), 1.0);
+        assert_eq!(regression.get_points_sorted().len(), 3);
+        assert_eq!(*regression.get_points_sorted()[0].y(), 3.0);
+        assert_eq!(*regression.get_points_sorted()[1].y(), 2.25);
+        assert_eq!(*regression.get_points_sorted()[2].y(), 1.0);
     }
 
     #[test]
@@ -474,9 +500,9 @@ mod tests {
             IsotonicRegression::new_ascending(&[Point::new(0.0, 1.0), Point::new(2.0, 2.0)])
                 .unwrap();
         regression.add_points(&[Point::new(1.0, 1.5)]);
-        assert_eq!(regression.get_points().len(), 3);
-        assert_eq!(*regression.get_points()[1].x(), 1.0);
-        assert_eq!(*regression.get_points()[1].y(), 1.5);
+        assert_eq!(regression.get_points_sorted().len(), 3);
+        assert_eq!(*regression.get_points_sorted()[1].x(), 1.0);
+        assert_eq!(*regression.get_points_sorted()[1].y(), 1.5);
     }
 
     #[test]
@@ -488,9 +514,9 @@ mod tests {
         ])
         .unwrap();
         regression.remove_points(&[Point::new(1.0, 2.0)]);
-        assert_eq!(regression.get_points().len(), 2);
-        assert_eq!(*regression.get_points()[0].x(), 0.0);
-        assert_eq!(*regression.get_points()[1].x(), 2.0);
+        assert_eq!(regression.get_points_sorted().len(), 2);
+        assert_eq!(*regression.get_points_sorted()[0].x(), 0.0);
+        assert_eq!(*regression.get_points_sorted()[1].x(), 2.0);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,5 +50,5 @@ pub mod point;
 pub mod isotonic_regression;
 
 pub use coordinate::Coordinate;
-pub use point::Point;
 pub use isotonic_regression::IsotonicRegression;
+pub use point::Point;

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,5 +1,5 @@
-use serde::Serialize;
 use crate::coordinate::Coordinate;
+use serde::Serialize;
 
 /// A point in 2D cartesian space
 #[derive(Debug, PartialEq, Copy, Clone, Serialize)]
@@ -110,8 +110,10 @@ impl<T: Coordinate> Point<T> {
     /// ```
     pub fn merge_with(&mut self, other: &Point<T>) {
         let total_weight = self.weight + other.weight;
-        self.x = (self.x * T::from_float(self.weight) + other.x * T::from_float(other.weight)) / T::from_float(total_weight);
-        self.y = (self.y * T::from_float(self.weight) + other.y * T::from_float(other.weight)) / T::from_float(total_weight);
+        self.x = (self.x * T::from_float(self.weight) + other.x * T::from_float(other.weight))
+            / T::from_float(total_weight);
+        self.y = (self.y * T::from_float(self.weight) + other.y * T::from_float(other.weight))
+            / T::from_float(total_weight);
         self.weight = total_weight;
     }
 }


### PR DESCRIPTION
This pull request changes the internal representation of points inside IsotonicRegression to use the Eytzinger layout, rather than keeping them in sorted order. The Eytzinger layout is more performant for binary search operations as it minimizes cache misses. When performing binary searches, it only requires forward memory movement and reduces the number of long jumps at the beginning.

The changes are split into two commits:
1. Code formatting
2. Implementation of the Eytzinger layout

Additionally, this PR fixes a bug where the centroid point was incorrectly weighted. Previously, the centroid's weight was calculated from the sum and then had points added again, effectively doubling its intended weight. This has been corrected to prevent the double-counting of points in the centroid's weight calculation.